### PR TITLE
Add a enum compression strategy

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,13 @@ var debug = require('simple-debug')('consulate-simple-secrets')
 var MS_PER_HOUR = 60 * 60 * 1000
   , DEFAULT_TTL = Math.pow(2, 16) * MS_PER_HOUR;
 
+/**
+ * Simple Secrets issue token for consulate
+ *
+ * @param {Object} options
+ * @return {Function}
+ */
+
 module.exports = function(options) {
   // Check that they gave us a key to sign
   if (!options || !options.key) throw new Error("Missing a `key` for simple-secrets signer");
@@ -25,25 +32,34 @@ module.exports = function(options) {
 
   debug('using ttl of', ttl);
 
-  // Allow the consumer to map scopes to a compressed enum value
-  var compressScope = options.compressScope || function(scope) { return scope };
-
   function register(app) {
+
+    // Save the `scopes` callback for compression
+    var getScopes = app.callback('scopes');
+
+    // Allow the consumer to map scopes to a compressed enum value
+    var compress = options.compressScope || compressScope;
+
     app.issueToken(function(client, user, scope, done) {
       debug('issuing token for client', client, 'and user', user, 'with scope', scope);
 
-      // Create a token with simple-secrets
-      // We use short variable names since we want to keep the size of our token down
-      var token = sender.pack({
-        u: user.id,
-        s: compressScope(scope),
-        c: client.id,
-        e: expire(ttl)
+      // Get a list of the scopes enum
+      getScopes(function(err, scopesEnum) {
+        if (err) return done(err);
+
+        // Create a token with simple-secrets
+        // We use short variable names since we want to keep the size of our token down
+        var token = sender.pack({
+          u: user.id,
+          s: compress(scope, scopesEnum),
+          c: client.id,
+          e: expire(ttl)
+        });
+
+        debug('issued token', token);
+
+        done(null, token);
       });
-
-      debug('issued token', token);
-
-      done(null, token);
     });
   };
 
@@ -52,6 +68,28 @@ module.exports = function(options) {
 
   return register;
 };
+
+/**
+ * Compress scopes with an emum into an efficient integer
+ */
+
+function compressScope(scope, scopesEnum) {
+  var scopes = typeof scope === 'string'
+    ? scope.split(' ')
+    : scope;
+
+  var value = '1' + scopesEnum.map(function(scope) {
+    return !!~scopes.indexOf(scope) ? '1' : '0';
+  }).join('');
+
+  debug('compressing', scopes, 'into', value+'b');
+
+  return parseInt(value, 2);
+};
+
+// Expose compressScope for testing
+
+if (process.env.NODE_ENV === 'test') module.exports.compressScope = compressScope;
 
 /**
  * Create a super-small expiration date

--- a/test/simple-secrets.test.js
+++ b/test/simple-secrets.test.js
@@ -21,6 +21,11 @@ describe('consulate-simple-secrets', function() {
       'issueToken': function(fn) {
         app.callbacks.issueToken = fn;
       },
+      'callback': function() {
+        return function(done) {
+          done(null, ['user:email', 'user:name', 'user:address']);
+        }
+      },
       callbacks: {}
     };
   });
@@ -48,10 +53,24 @@ describe('consulate-simple-secrets', function() {
       should.exist(tokenInfo.e);
       tokenInfo.c.should.eql('clientId');
       tokenInfo.u.should.eql('userId');
-      tokenInfo.s.should.eql(['user:email', 'user:name']);
+      tokenInfo.s.should.eql(14);
 
       done();
     });
+  });
+
+  it('should efficiently compress a scopes list', function() {
+    var requestedScopes = ['user:email', 'app:products']
+      , scopesEnum = [
+          'user:name',
+          'user:email',
+          'user:address',
+          null, // used for a placeholder i.e. so we can add 'user:phone' in the future
+          'app:products',
+          'app:products:edit'
+        ];
+
+    ssPlugin.compressScope(requestedScopes, scopesEnum).should.eql(82);
   });
 
 });


### PR DESCRIPTION
This gives users a default compression strategy. It works by setting a bit string for the enum values and converts it into an integer.

Example:

If we had the following as our scopes enum:

``` js
['users', 'products', 'sales', 'clients', 'emails'];
```

and made a scopes request like the following:

``` js
['products', 'clients'];
```

we would end up with:

``` js
42 or 101010b
```

where we prefix the value with `1` so we don't lose any digits.

| 1 | 0 | 1 | 0 | 1 | 0 |
| --- | --- | --- | --- | --- | --- |
| _prefix_ | users | products | sales | clients | emails |
